### PR TITLE
Fix --update for pkgs with same nevra. BZ 1174380

### DIFF
--- a/createrepo/readMetadata.py
+++ b/createrepo/readMetadata.py
@@ -108,7 +108,16 @@ class MetadataIndex(object):
         """
         if relpath in self.pkg_tups_by_path:
             pkgtup = self.pkg_tups_by_path[relpath]
-            return self._repo.sack.searchPkgTuple(pkgtup)[0]
+            pos = self._repo.sack.searchPkgTuple(pkgtup)
+            if len(pos) == 1:
+                return pos[0]
+            elif len(pos) > 1:
+                # Multiple matches for this pkgtup so look at their relpath
+                if self.opts.get('verbose'):
+                    print _("Warning: Duplicate nevra detected for %s") % relpath
+                for po in pos:
+                    if po.relativepath == relpath:
+                        return po
         return None
 
     


### PR DESCRIPTION
Make sure we don't mess up the primary file on --update by writing
duplicate entries to it when the repo contains multiple rpms with the
same nevra in their headers.
