### PR TITLE
Add safety check for oldData attribute

### DIFF
--- a/createrepo/__init__.py
+++ b/createrepo/__init__.py
@@ -1484,7 +1484,7 @@ class MetaDataGenerator:
 
 
     def _cleanup_update_tmp_dir(self):
-        if self.conf.update:
+        if self.conf.update and hasattr(self, 'oldData'):
             self.oldData.cleanup()
 
 


### PR DESCRIPTION
We may not have it set up yet at the point of calling the cleanup
method.