### PR TITLE
modifyrepo: handle empty file with LZMA. BZ 1287685

### DIFF
--- a/modifyrepo.py
+++ b/modifyrepo.py
@@ -125,6 +125,9 @@ class RepoMetadata:
         else:
             raise MDError, 'invalid metadata type'
 
+        if not md and self.compress_type == 'xz':
+            raise MDError, 'LZMA does not support compressing empty files'
+
         ## Compress the metadata and move it into the repodata
         mdtype = self._get_mdtype(mdname, mdtype)
         destmd = os.path.join(self.repodir, mdname)


### PR DESCRIPTION
When trying to compress an empty string with LZMA, we will get the
unfriendly "LZMA.error: unknown error!".  Let's handle this case
ourselves and raise a more user-friendly error instead.