### PR TITLE
modifyrepo: docs: remove compat compress type. BZ 1287714

### DIFF
--- a/docs/modifyrepo.1
+++ b/docs/modifyrepo.1
@@ -24,7 +24,7 @@ Compress the new repodata before adding it to the repo. This is used by default.
 Do not compress the new repodata before adding it to the repo.
 
 .IP "\fB\-\-compress-type <compress-type>\fP"
-Specify which compression type to use: compat (default), xz (may not be available), gz, bz2.
+Specify which compression type to use: gz, xz (may not be available), bz2.
 
 .IP "\fB\-s, \-\-checksum <sumtype>\fP"
 Specify the checksum type to use.


### PR DESCRIPTION
We never supported "compat" here as it only makes sense in the
createrepo domain (it means use a different method for the xml files
(gz) and for the sqlite files (bzip2) -- we don't generate sqlite files
in modifyrepo).