### PR TITLE
createrepo: using shutil.move instead of os.rename

### DIFF
--- a/createrepo/__init__.py
+++ b/createrepo/__init__.py
@@ -1287,7 +1287,7 @@ class MetaDataGenerator:
                         compress_type = 'bz2'
                         
                     # rename from silly name to not silly name
-                    os.rename(tmp_result_path, resultpath)
+                    shutil.move(tmp_result_path, resultpath)
                     compressed_name = '%s.%s' % (good_name, compress_type)
                     result_compressed = os.path.join(repopath, compressed_name)
                     db_csums[ftype] = misc.checksum(sumtype, resultpath)
@@ -1308,7 +1308,7 @@ class MetaDataGenerator:
                                            db_compressed_sums[ftype], good_name, compress_type)
                         csum_result_compressed =  os.path.join(repopath,
                                                            csum_compressed_name)
-                        os.rename(result_compressed, csum_result_compressed)
+                        shutil.move(result_compressed, csum_result_compressed)
                         result_compressed = csum_result_compressed
                         compressed_name = csum_compressed_name
 
@@ -1345,7 +1345,7 @@ class MetaDataGenerator:
                 res_file = '%s-%s.%s' % (csum, main_name, self.conf.compress_type)
                 orig_file = os.path.join(repopath, rpm_file)
                 dest_file = os.path.join(repopath, res_file)
-                os.rename(orig_file, dest_file)
+                shutil.move(orig_file, dest_file)
             else:
                 res_file = rpm_file
             rpm_file = res_file
@@ -1403,7 +1403,7 @@ class MetaDataGenerator:
 
         if os.path.exists(output_final_dir):
             try:
-                os.rename(output_final_dir, output_old_dir)
+                shutil.move(output_final_dir, output_old_dir)
             except:
                 raise MDError, _('Error moving final %s to old dir %s' % (
                                  output_final_dir, output_old_dir))
@@ -1411,10 +1411,10 @@ class MetaDataGenerator:
         output_temp_dir = os.path.join(self.conf.outputdir, self.conf.tempdir)
 
         try:
-            os.rename(output_temp_dir, output_final_dir)
+            shutil.move(output_temp_dir, output_final_dir)
         except:
             # put the old stuff back
-            os.rename(output_old_dir, output_final_dir)
+            shutil.move(output_old_dir, output_final_dir)
             raise MDError, _('Error moving final metadata into place')
 
         for f in ['primaryfile', 'filelistsfile', 'otherfile', 'repomdfile',
@@ -1483,7 +1483,7 @@ class MetaDataGenerator:
                     'Could not remove old metadata file: %s: %s') % (oldfile, e)
             else:
                 try:
-                    os.rename(oldfile, finalfile)
+                    shutil.move(oldfile, finalfile)
                 except OSError, e:
                     msg = _('Could not restore old non-metadata file: %s -> %s') % (oldfile, finalfile)
                     msg += _('Error was %s') % e

--- a/createrepo/utils.py
+++ b/createrepo/utils.py
@@ -19,6 +19,7 @@
 import os
 import os.path
 import re
+import shutil
 import sys
 import bz2
 import gzip
@@ -179,7 +180,7 @@ def checksum_and_rename(fn_path, sumtype='sha256'):
         fn = fn_match.groups()[0]
     csum_fn = csum + '-' + fn
     csum_path = os.path.join(fndir, csum_fn)
-    os.rename(fn_path, csum_path)
+    shutil.move(fn_path, csum_path)
     return (csum, csum_path)
 
 

--- a/createrepo/yumbased.py
+++ b/createrepo/yumbased.py
@@ -16,6 +16,7 @@
 
 
 import os
+import shutil
 def _get_umask():
    oumask = os.umask(0)
    os.umask(oumask)
@@ -94,7 +95,7 @@ class CreateRepoPackage(YumLocalPackage):
                 #  tempfile forces 002 ... we want to undo that, so that users
                 # can share the cache. BZ 833350.
                 os.chmod(tmpfilename, 0666 ^ _b4rpm_oumask)
-                os.rename(tmpfilename, csumfile)
+                shutil.move(tmpfilename, csumfile)
             except:
                 pass
 


### PR DESCRIPTION
This is to prevent "Invalid cross device link" errors especially inside docker
containers with various overlayfs layers.