### PR TITLE
Atomically replace repomd file

### DIFF
--- a/modifyrepo.py
+++ b/modifyrepo.py
@@ -87,7 +87,7 @@ class RepoMetadata:
         outmd = file(tmpfile, 'w')
         outmd.write(self.repoobj.dump_xml())
         outmd.close()
-        os.replace(tmpfile, self.repomdxml)
+        os.rename(tmpfile, self.repomdxml)
         print "Wrote:", self.repomdxml
 
     def _remove_repodata_file(self, repodata):

--- a/modifyrepo.py
+++ b/modifyrepo.py
@@ -81,9 +81,13 @@ class RepoMetadata:
 
     def _write_repomd(self):
         """ Write the updated repomd.xml. """
-        outmd = file(self.repomdxml, 'w')
+
+        # Atomically replace contents
+        tmpfile = os.path.join(self.repodir, ".repomd.xml.new")
+        outmd = file(tmpfile, 'w')
         outmd.write(self.repoobj.dump_xml())
         outmd.close()
+        os.replace(tmpfile, self.repomdxml)
         print "Wrote:", self.repomdxml
 
     def _remove_repodata_file(self, repodata):


### PR DESCRIPTION
Right now, if the modifyrepo script crashes (hardware issue, server reboot, etc.) while it's writing repomd.xml, it will leave it as an empty file.

With this change, we do a filesystem-level atomic operation to update the file, so it's never left in a bad state.